### PR TITLE
Move all rich handling into `console` module

### DIFF
--- a/anaconda_conda_tos/console/__init__.py
+++ b/anaconda_conda_tos/console/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (C) 2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Render functions for console output."""
+
+from .render import list_tos  # noqa: F401

--- a/anaconda_conda_tos/console/mappers.py
+++ b/anaconda_conda_tos/console/mappers.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Mappers to aid in rendering of console output."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..models import MetadataPathPair
+
+
+def version_mapping(metadata_pair: MetadataPathPair | None) -> str:
+    """Map the ToS version to a human-readable string."""
+    if not metadata_pair or metadata_pair.metadata.tos_version is None:
+        return "-"
+    return str(metadata_pair.metadata.tos_version)
+
+
+def accepted_mapping(metadata_pair: MetadataPathPair | None) -> str:
+    """Map the ToS acceptance status to a human-readable string."""
+    if not metadata_pair:
+        return "-"
+
+    tos_accepted = metadata_pair.metadata.tos_accepted
+    acceptance_timestamp = metadata_pair.metadata.acceptance_timestamp
+    if tos_accepted is None:
+        # neither accepted nor rejected
+        return "-"
+    elif tos_accepted:
+        if acceptance_timestamp:
+            # convert timestamp to localized time
+            return acceptance_timestamp.astimezone().isoformat(" ")
+        else:
+            # accepted but no timestamp
+            return "unknown"
+    else:
+        return "rejected"
+
+
+def path_mapping(metadata_pair: MetadataPathPair | None) -> str:
+    """Map the ToS path to a human-readable string."""
+    if not metadata_pair:
+        return "-"
+    return str(metadata_pair.path.parent.parent)

--- a/anaconda_conda_tos/console/render.py
+++ b/anaconda_conda_tos/console/render.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2024 Anaconda, Inc
+# SPDX-License-Identifier: BSD-3-Clause
+"""Render functions for console output."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rich.console import Console
+from rich.table import Table
+
+from ..tos import get_tos
+from .mappers import accepted_mapping, path_mapping, version_mapping
+
+if TYPE_CHECKING:
+    from conda.models.channel import Channel
+
+
+def list_tos(*channels: str | Channel) -> None:
+    """Printout listing of unaccepted, accepted, and rejected ToS."""
+    table = Table()
+    table.add_column("Channel")
+    table.add_column("Version")
+    table.add_column("Accepted")
+    table.add_column("Location")
+
+    for channel, metadata_pair in get_tos(*channels):
+        table.add_row(
+            channel.base_url,
+            version_mapping(metadata_pair),
+            accepted_mapping(metadata_pair),
+            path_mapping(metadata_pair),
+        )
+
+    console = Console()
+    console.print(table)

--- a/anaconda_conda_tos/plugin.py
+++ b/anaconda_conda_tos/plugin.py
@@ -10,17 +10,14 @@ from conda.base.context import context
 from conda.cli.install import validate_prefix_exists
 from conda.common.configuration import PrimitiveParameter
 from conda.plugins import CondaSetting, CondaSubcommand, hookimpl
-from rich.console import Console
-from rich.table import Table
 
+from .console import list_tos
 from .path import SYSTEM_TOS_ROOT, USER_TOS_ROOT
-from .tos import accept_tos, get_tos, reject_tos, view_tos
+from .tos import accept_tos, reject_tos, view_tos
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
     from typing import Iterator
-
-    from .models import MetadataPathPair
 
 
 def configure_parser(parser: ArgumentParser) -> None:
@@ -51,41 +48,6 @@ def configure_parser(parser: ArgumentParser) -> None:
     action.add_argument("--view", "--show", action="store_true")
 
 
-def version_mapping(metadata_pair: MetadataPathPair | None) -> str:
-    """Map the ToS version to a human-readable string."""
-    if not metadata_pair or metadata_pair.metadata.tos_version is None:
-        return "-"
-    return str(metadata_pair.metadata.tos_version)
-
-
-def accepted_mapping(metadata_pair: MetadataPathPair | None) -> str:
-    """Map the ToS acceptance status to a human-readable string."""
-    if not metadata_pair:
-        return "-"
-
-    tos_accepted = metadata_pair.metadata.tos_accepted
-    acceptance_timestamp = metadata_pair.metadata.acceptance_timestamp
-    if tos_accepted is None:
-        # neither accepted nor rejected
-        return "-"
-    elif tos_accepted:
-        if acceptance_timestamp:
-            # convert timestamp to localized time
-            return acceptance_timestamp.astimezone().isoformat(" ")
-        else:
-            # accepted but no timestamp
-            return "unknown"
-    else:
-        return "rejected"
-
-
-def path_mapping(metadata_pair: MetadataPathPair | None) -> str:
-    """Map the ToS path to a human-readable string."""
-    if not metadata_pair:
-        return "-"
-    return str(metadata_pair.path.parent.parent)
-
-
 def execute(args: Namespace) -> int:
     """Execute the `tos` subcommand."""
     validate_prefix_exists(context.target_prefix)
@@ -97,22 +59,7 @@ def execute(args: Namespace) -> int:
     elif args.view:
         view_tos(*context.channels)
     else:
-        table = Table()
-        table.add_column("Channel")
-        table.add_column("Version")
-        table.add_column("Accepted")
-        table.add_column("Location")
-
-        for channel, metadata_pair in get_tos(*context.channels):
-            table.add_row(
-                channel.base_url,
-                version_mapping(metadata_pair),
-                accepted_mapping(metadata_pair),
-                path_mapping(metadata_pair),
-            )
-
-        console = Console()
-        console.print(table)
+        list_tos(*context.channels)
     return 0
 
 


### PR DESCRIPTION
Instead of hiding all of the table & console rendering alongside actual logic we tuck all of the console work into a dedicated module.