### PR TITLE
Correct model inheritance

### DIFF
--- a/anaconda_conda_tos/console/mappers.py
+++ b/anaconda_conda_tos/console/mappers.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 def accepted_mapping(metadata: RemoteToSMetadata | LocalToSMetadata) -> str:
     """Map the ToS acceptance status to a human-readable string."""
-    if type(metadata) is RemoteToSMetadata:
+    if isinstance(metadata, RemoteToSMetadata):
         return "-"
 
     tos_accepted = metadata.tos_accepted

--- a/anaconda_conda_tos/models.py
+++ b/anaconda_conda_tos/models.py
@@ -6,72 +6,62 @@ from __future__ import annotations
 
 from datetime import datetime  # noqa: TCH003 # needed for Pydantic model
 from pathlib import Path  # noqa: TCH003 # needed for Pydantic model
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    model_validator,
-)
+from pydantic import BaseModel, ConfigDict
 
 if TYPE_CHECKING:
     from typing import Self
 
 
-class RemoteToSMetadata(BaseModel):
-    """Conda ToS metadata schema for the remote endpoint."""
-
+class _ToSMetadata(BaseModel):
     model_config = ConfigDict(extra="allow")
     tos_version: int
     text: str
 
-    def __ge__(self: Self, other: RemoteToSMetadata) -> bool:
+    def __ge__(self: Self, other: _ToSMetadata) -> bool:
         """Compare the ToS metadata version."""
-        if not isinstance(other, RemoteToSMetadata):
+        if not isinstance(other, _ToSMetadata):
             return NotImplemented
         return self.tos_version >= other.tos_version
 
 
-class LocalToSMetadata(RemoteToSMetadata):
+class RemoteToSMetadata(_ToSMetadata):
+    """Conda ToS metadata schema for the remote endpoint."""
+
+
+class LocalToSMetadata(_ToSMetadata):
     """Conda ToS metadata schema with acceptance fields."""
 
     base_url: str
     tos_accepted: bool
     acceptance_timestamp: datetime
 
-    @model_validator(mode="after")
-    def _required(self: Self) -> Self:
-        if (self.tos_accepted is None) is not (self.acceptance_timestamp is None):
-            raise ValueError(
-                "`tos_accepted` and `acceptance_timestamp` must be provided together."
-            )
-        return self
 
-
-class MetadataPathPair(BaseModel):
-    """Tuple of ToS metadata and path."""
-
-    # FUTURE: Python 3.10+, switch to `LocalToSMetadata | RemoteToSMetadata`
-    metadata: Union[LocalToSMetadata, RemoteToSMetadata]  # noqa: UP007
+class _MetadataPathPair(BaseModel):
+    metadata: _ToSMetadata
     # FUTURE: Python 3.10+, switch to `Path | None`
-    path: Optional[Path] = Field(None)  # noqa: UP007
+    path: Optional[Path]  # noqa: UP007
 
-    @model_validator(mode="after")
-    def _required(self: Self) -> Self:
-        if type(self.metadata) is RemoteToSMetadata:
-            self.path = None
-        elif type(self.metadata) is LocalToSMetadata and not self.path:
-            raise ValueError(
-                "`path` must be provided when metadata is a LocalToSMetadata."
-            )
-        return self
-
-    def __lt__(self: Self, other: MetadataPathPair) -> bool:
+    def __lt__(self: Self, other: _MetadataPathPair) -> bool:
         """Compare the ToS metadata version.
 
         Critical for sorting a list of ToS metadata path pairs.
         """
-        if not isinstance(other, MetadataPathPair):
+        if not isinstance(other, _MetadataPathPair):
             return NotImplemented
         return self.metadata.tos_version < other.metadata.tos_version
+
+
+class RemotePair(_MetadataPathPair):
+    """Tuple of remote ToS metadata and no path."""
+
+    metadata: RemoteToSMetadata
+    path: None = None
+
+
+class LocalPair(_MetadataPathPair):
+    """Tuple of local ToS metadata and path."""
+
+    metadata: LocalToSMetadata
+    path: Path

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,15 +10,12 @@ import pytest
 from conda.base.context import context
 from conda.models.channel import Channel
 
-from anaconda_conda_tos.api import (
-    get_channels,
-    get_one_tos,
-    get_stored_tos,
-)
+from anaconda_conda_tos.api import get_channels, get_one_tos, get_stored_tos
 from anaconda_conda_tos.exceptions import CondaToSMissingError
 from anaconda_conda_tos.models import (
+    LocalPair,
     LocalToSMetadata,
-    MetadataPathPair,
+    RemotePair,
     RemoteToSMetadata,
 )
 
@@ -39,8 +36,8 @@ def test_get_channels() -> None:
 
 
 @pytest.fixture(scope="session")
-def remote_metadata_pair() -> MetadataPathPair:
-    return MetadataPathPair(
+def remote_metadata_pair() -> RemotePair:
+    return RemotePair(
         metadata=RemoteToSMetadata(
             tos_version=2,
             text="new ToS",
@@ -50,10 +47,10 @@ def remote_metadata_pair() -> MetadataPathPair:
 
 @pytest.fixture(scope="session")
 def local_metadata_pair(
-    remote_metadata_pair: MetadataPathPair,
+    remote_metadata_pair: RemotePair,
     sample_channel: Channel,
-) -> MetadataPathPair:
-    return MetadataPathPair(
+) -> LocalPair:
+    return LocalPair(
         metadata=LocalToSMetadata(
             **remote_metadata_pair.metadata.model_dump(),
             base_url=sample_channel.base_url,
@@ -65,8 +62,8 @@ def local_metadata_pair(
 
 
 @pytest.fixture(scope="session")
-def old_metadata_pair(sample_channel: Channel) -> MetadataPathPair:
-    return MetadataPathPair(
+def old_metadata_pair(sample_channel: Channel) -> LocalPair:
+    return LocalPair(
         metadata=LocalToSMetadata(
             tos_version=1,
             text="old ToS",
@@ -82,9 +79,9 @@ def test_get_single_metadata(
     mocker: MockerFixture,
     tmp_path: Path,
     sample_channel: Channel,
-    remote_metadata_pair: MetadataPathPair,
-    local_metadata_pair: MetadataPathPair,
-    old_metadata_pair: MetadataPathPair,
+    remote_metadata_pair: RemotePair,
+    local_metadata_pair: LocalPair,
+    old_metadata_pair: LocalPair,
 ) -> None:
     # mock remote ToS and no local ToS
     mocker.patch(
@@ -131,9 +128,9 @@ def test_get_stored_metadatas(
     mocker: MockerFixture,
     tmp_path: Path,
     sample_channel: Channel,
-    remote_metadata_pair: MetadataPathPair,
-    local_metadata_pair: MetadataPathPair,
-    old_metadata_pair: MetadataPathPair,
+    remote_metadata_pair: RemotePair,
+    local_metadata_pair: LocalPair,
+    old_metadata_pair: LocalPair,
 ) -> None:
     # mock no remote ToS
     mocker.patch(

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -14,13 +14,12 @@ from pydantic import ValidationError
 
 from anaconda_conda_tos.exceptions import CondaToSMissingError, CondaToSPermissionError
 from anaconda_conda_tos.local import (
-    LocalToSMetadata,
     get_local_metadata,
     get_local_metadatas,
     read_metadata,
     write_metadata,
 )
-from anaconda_conda_tos.models import MetadataPathPair, RemoteToSMetadata
+from anaconda_conda_tos.models import LocalPair, LocalToSMetadata, RemoteToSMetadata
 from anaconda_conda_tos.path import get_metadata_path
 
 if TYPE_CHECKING:
@@ -74,13 +73,13 @@ def test_write_metadata(tmp_path: Path) -> None:
         REMOTE_METADATA,
         tos_accepted=True,
     )
-    assert isinstance(metadata_pair, MetadataPathPair)
+    assert isinstance(metadata_pair, LocalPair)
     assert _similar_metadata(metadata_pair.metadata, LOCAL_METADATA)
     assert metadata_pair.path == path
 
     # write with LocalToSMetadata
     metadata_pair = write_metadata(tmp_path, CHANNEL, LOCAL_METADATA, tos_accepted=True)
-    assert isinstance(metadata_pair, MetadataPathPair)
+    assert isinstance(metadata_pair, LocalPair)
     assert _similar_metadata(metadata_pair.metadata, LOCAL_METADATA)
     assert metadata_pair.path == path
 


### PR DESCRIPTION
Addresses https://github.com/anaconda/anaconda-conda-tos/pull/57#discussion_r1831679853

Here we correct the class inheritance for the metadata models to improve usage elsewhere (i.e., we can use `isinstance` instead of needing to use `type`)