### PR TITLE
Use dependencies from `conda-canary`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,17 +21,19 @@ requirements:
     - setuptools-scm
   run:
     - python >=3.9
-    - conda >24.9.2
+    - conda-canary/label/dev::conda >24.9.2
     - rich
     - pydantic
 
 test:
+  requires:
+    - pip
+    - conda-canary/label/dev::conda >24.9.2
   imports:
     - anaconda_conda_tos
   commands:
     - pip check
-  requires:
-    - pip
+    - conda tos --version
 
 about:
   home: https://github.com/anaconda/{{ name }}


### PR DESCRIPTION
[Resolving canary build failures](https://github.com/anaconda/anaconda-conda-tos/actions/runs/11841666426/job/33001003782) by installing `conda` from `conda-canary` since the necessary plugin hooks are not released yet.