### PR TITLE
Only build noarch on linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -197,13 +197,7 @@ jobs:
       matrix:
         include:
           - runner: ubuntu-latest
-            subdir: linux-64
-          - runner: macos-13
-            subdir: osx-64
-          - runner: macos-latest
-            subdir: osx-arm64
-          - runner: windows-latest
-            subdir: win-64
+            subdir: noarch
     runs-on: ${{ matrix.runner }}
     steps:
       # Clean checkout of specific git ref needed for package metadata version


### PR DESCRIPTION
The recipe is `noarch` so the `subdir` is `noarch` and we only need to build on Linux.