### PR TITLE
Test improvements

### DIFF
--- a/conda_anaconda_tos/console/render.py
+++ b/conda_anaconda_tos/console/render.py
@@ -30,8 +30,12 @@ from .prompt import FuzzyPrompt
 if TYPE_CHECKING:
     import os
     from collections.abc import Iterable
+    from typing import Final
 
     from conda.models.channel import Channel
+
+
+TOS_OUTDATED: Final = "* ToS version(s) are outdated."
 
 
 def render_list(
@@ -69,7 +73,7 @@ def render_list(
     console = console or Console()
     console.print(table)
     if outdated:
-        console.print("[bold yellow]* ToS version(s) are outdated.")
+        console.print(f"[bold yellow]{TOS_OUTDATED}")
     return 0
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 import pytest
@@ -15,7 +16,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
 
-    from pytest import MonkeyPatch, TempPathFactory
+    from pytest import FixtureRequest, MonkeyPatch, TempPathFactory
     from pytest_mock import MockerFixture
 
     from conda_anaconda_tos.models import RemoteToSMetadata
@@ -91,3 +92,15 @@ def mock_channels(
         return_value=(channels := (tos_channel, sample_channel)),
     )
     return channels
+
+
+@pytest.fixture
+def terminal_width(mocker: MockerFixture, request: FixtureRequest) -> int:
+    """Mock the terminal width for console output.
+
+    If the default width is not sufficient, use an `indirect=True` parameterization with
+    the desired width.
+    """
+    width = getattr(request, "param", 200)
+    mocker.patch("os.get_terminal_size", return_value=os.terminal_size((width, 200)))
+    return width

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 from __future__ import annotations
 
-import os
 import sys
 from io import StringIO
 from typing import TYPE_CHECKING
@@ -27,7 +26,6 @@ if TYPE_CHECKING:
     from conda.models.channel import Channel
     from conda.testing.fixtures import CondaCLIFixture
     from pytest import MonkeyPatch
-    from pytest_mock import MockerFixture
 
     from conda_anaconda_tos.models import RemoteToSMetadata
 
@@ -120,14 +118,13 @@ def test_subcommand_tos_reject(
 
 
 def test_subcommand_tos_list(
-    mocker: MockerFixture,
     conda_cli: CondaCLIFixture,
     mock_channels: tuple[Channel, Channel],
     mock_search_path: tuple[Path, Path],
+    terminal_width: int,  # noqa: ARG001
 ) -> None:
     system_tos_root, user_tos_root = mock_search_path
     tos_channel, sample_channel = mock_channels
-    mocker.patch("os.get_terminal_size", return_value=os.terminal_size((200, 200)))
 
     out, err, code = conda_cli("tos")
     assert tos_channel.base_url in out


### PR DESCRIPTION
* Make `tos_server` fixture session scoped to speedup testing (5x faster)
* Convert terminal width mocking into a fixture with an option to control the width via `indirect=True`
* Add test for #113