### PR TITLE
Improve error messaging

### DIFF
--- a/conda_anaconda_tos/exceptions.py
+++ b/conda_anaconda_tos/exceptions.py
@@ -58,8 +58,8 @@ class CondaToSRejectedError(CondaToSError):
     def __init__(self: Self, *channels: str | Channel) -> None:
         """Format error message with channel base URL."""
         super().__init__(
-            f"Terms of Service has been rejected for the following channels, "
-            f"please remove or accept them before proceeding:\n"
+            f"Terms of Service has been rejected for the following channels. "
+            f"Please remove or accept them before proceeding:\n"
             f"{_bullet(map(_url, channels))}\n"
             f"\n"
             f"To remove channels with rejected Terms of Service, run the following and "
@@ -78,8 +78,8 @@ class CondaToSNonInteractiveError(CondaToSError):
     def __init__(self: Self, *channels: str | Channel) -> None:
         """Format error message with channel base URL."""
         super().__init__(
-            f"Terms of Service have not been accepted for the following channels, "
-            f"please accept or remove them before proceeding:\n"
+            f"Terms of Service have not been accepted for the following channels. "
+            f"Please accept or remove them before proceeding:\n"
             f"{_bullet(map(_url, channels))}\n"
             f"\n"
             f"To accept a channel's Terms of Service, run the following and "


### PR DESCRIPTION
The error messages need to inform the user what to do to resolve the issue.

| Error | CLI | Navigator |
|---|---|---|
| `CondaToSNonInteractive` | ![][cli-noninteractive] | ![][navigator-noninteractive] |
| `CondaToSRejected` | ![][cli-rejected] | ![][navigator-rejected] |

[navigator-rejected]: https://github.com/user-attachments/assets/1c78b49f-16e8-4e22-9a08-74989d57fc44
[navigator-noninteractive]: https://github.com/user-attachments/assets/17d4fd8c-3309-419d-8387-8d7b2db09760
[cli-noninteractive]: https://github.com/user-attachments/assets/345d2618-8b40-4bce-aa3b-4d731edbee0e
[cli-rejected]: https://github.com/user-attachments/assets/0e729273-ee5c-4a95-9239-6e9bc9ae460b

I've experimented a little with spacing and rendering and found that navigator strips out any leading indentations so I opted to use bullet points and newlines to aid in readability.