### PR TITLE
Include outdated ToS info in interactive

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,6 @@ def terminal_width(mocker: MockerFixture, request: FixtureRequest) -> int:
     If the default width is not sufficient, use an `indirect=True` parameterization with
     the desired width.
     """
-    width = getattr(request, "param", 200)
+    width = getattr(request, "param", 500)
     mocker.patch("os.get_terminal_size", return_value=os.terminal_size((width, 200)))
     return width


### PR DESCRIPTION
Followup to #112 

When a new ToS is available include details about the prior acceptance/rejection to the user:

<img width="957" alt="Screenshot 2024-12-05 at 12 08 23" src="https://github.com/user-attachments/assets/29b15483-2e24-4af3-99c3-3b5cfba29a1c">

<img width="956" alt="Screenshot 2024-12-05 at 12 08 46" src="https://github.com/user-attachments/assets/2f1a0fcc-d1cf-4d1b-b972-537991b00165">

Versus what happens from a blank state:

<img width="901" alt="Screenshot 2024-12-05 at 12 33 49" src="https://github.com/user-attachments/assets/3e19bd2a-1de3-40fe-9875-c1b61a47524d">