### PR TITLE
Treat a Jupyter notebook as non-interactive

### DIFF
--- a/conda_anaconda_tos/api.py
+++ b/conda_anaconda_tos/api.py
@@ -24,6 +24,9 @@ if TYPE_CHECKING:
 #: Whether the current environment is a CI environment
 CI: Final = os.getenv("CI", "").lower() == "true"
 
+#: Whether the current environment is a Jupyter environment
+JUPYTER: Final = os.getenv("JPY_SESSION_NAME") and os.getenv("JPY_PARENT_PID")
+
 
 def get_channels(*channels: str | Channel) -> Iterable[Channel]:
     """Yield all unique channels from the given channels."""

--- a/conda_anaconda_tos/console/render.py
+++ b/conda_anaconda_tos/console/render.py
@@ -14,6 +14,7 @@ from rich.table import Table
 
 from ..api import (
     CI,
+    JUPYTER,
     accept_tos,
     clean_cache,
     clean_tos,
@@ -306,6 +307,8 @@ def render_interactive(  # noqa: C901
         raise CondaToSRejectedError(*rejected)
     elif CI:
         printer("[bold yellow]CI detected...")
+    elif JUPYTER:
+        printer("[bold yellow]Jupyter detected...")
 
     non_interactive = []
     for channel, pair in channel_pairs:
@@ -325,8 +328,8 @@ def render_interactive(  # noqa: C901
                 tos_root=tos_root,
                 cache_timeout=cache_timeout,
             ).metadata
-        elif json or always_yes:
-            # --json and --yes doesn't support interactive prompts
+        elif json or always_yes or JUPYTER:
+            # --json, --yes, and Jupyter doesn't support interactive prompts
             non_interactive.append(channel)
         elif _prompt_acceptance(channel, pair, console):
             # user manually accepted the Terms of Service


### PR DESCRIPTION
Provide special detection of Jupyter notebooks and treat it as a non-interactive case:

| Shell Command | Magic Command |
|---|---|
| ![][shell-noninteractive] | ![][magic-noninteractive] |
| ![][shell-rejected] | ![][magic-rejected] |

[magic-rejected]: https://github.com/user-attachments/assets/9388a2b8-5381-4196-ba9b-f83d5a09ab89
[shell-rejected]: https://github.com/user-attachments/assets/d7a00ee2-a4d8-48e1-bfc3-5619fec9b263
[magic-noninteractive]: https://github.com/user-attachments/assets/a8750eae-7b8e-4c8a-87a7-2b17ae28b345
[shell-noninteractive]: https://github.com/user-attachments/assets/35e1a570-959d-433a-9184-c2d01f091d5e