### PR TITLE
Bump `canary-release`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -188,11 +188,11 @@ jobs:
     if: >-
       !cancelled()
       && !github.event.repository.fork
-    #   && (
-    #     github.ref_name == 'main'
-    #     || startsWith(github.ref_name, 'feature/')
-    #     || endsWith(github.ref_name, '.x')
-    #   )
+      && (
+        github.ref_name == 'main'
+        || startsWith(github.ref_name, 'feature/')
+        || endsWith(github.ref_name, '.x')
+      )
     strategy:
       matrix:
         include:
@@ -250,7 +250,7 @@ jobs:
           Path(environ["GITHUB_ENV"]).write_text("\n".join(f"{name}={value}" for name, value in envs.items()))
 
       - name: Create & Upload
-        uses: conda/actions/canary-release@upload-dot-conda
+        uses: conda/actions/canary-release@8ff3faa82ad80f5c05d91c22bcd37d897f80ca46 # v25.1.1
         with:
           package-name: ${{ github.event.repository.name }}
           subdir: ${{ matrix.subdir }}


### PR DESCRIPTION
`conda-build` is changing the default package format from `.tar.bz2` to `.conda`. The old `canary-release` action did not account for `.conda` packages and needs updating to handle this format for uploads.

Xref https://github.com/anaconda/conda-anaconda-tos/actions/runs/12803843176/job/35697295074
Xref https://github.com/conda/actions/pull/250
Xref https://github.com/conda/actions/pull/251