### PR TITLE
Add mutable server tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
 
+    from http_test_server import MetadataType
     from pytest import FixtureRequest, MonkeyPatch, TempPathFactory
     from pytest_mock import MockerFixture
 
@@ -55,6 +56,25 @@ def sample_channel() -> Iterator[Channel]:
     """Serve the sample channel as-is without a `tos.json` endpoint."""
     with serve_channel(SAMPLE_CHANNEL_DIR, None) as url:
         yield Channel(url)
+
+
+@pytest.fixture
+def mutable_server() -> Iterator[tuple[Channel, list[MetadataType]]]:
+    metadatas: list[MetadataType] = []
+    with serve_channel(SAMPLE_CHANNEL_DIR, iter(metadatas)) as url:
+        yield Channel(url), metadatas
+
+
+@pytest.fixture
+def mutable_channel(mutable_server: tuple[Channel, list[MetadataType]]) -> Channel:
+    return mutable_server[0]
+
+
+@pytest.fixture
+def mutable_metadatas(
+    mutable_server: tuple[Channel, list[MetadataType]],
+) -> list[MetadataType]:
+    return mutable_server[1]
 
 
 @pytest.fixture


### PR DESCRIPTION
Adjust `http_test_server.py` to handle more drastic metadata changes. We can now test for a channel starting with no `tos.json` endpoint, then uploading a bad `tos.json` endpoint, to then uploading a valid `tos.json` endpoint, and finally removing the `tos.json` endpoint again.

The above tests can now be done manually:

```
python tests/http_test_server.py --missing-start --tos
```

and is also included in the pytest suite:

```
tests/test_remote.py::test_get_endpoint_mutable_server
tests/test_remote.py::test_get_remote_metadata_mutable_server
```