### PR TITLE
Fix `renovate.json`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,10 +14,10 @@
       "customType": "regex",
       "description": "Upgrade conda dependencies",
       "fileMatch": [
-        "(^|/)requirements(.*).txt$"
+        "(^|/)requirements(.*)\\.txt$"
       ],
       "matchStrings": [
-        "# renovate: datasource=conda depName=(?<depName>.*?)\\s+-\\s*[\\w-]+\\s*==?\\s*\"?(?<currentValue>.*)\"?"
+        "# renovate: datasource=conda depName=(?<depName>.*?)\\s+[\\w-]+\\s*==?\\s*\"?(?<currentValue>.*)\"?"
       ],
       "datasourceTemplate": "conda"
     }


### PR DESCRIPTION
The regex was expecting an environment.yaml format, e.g.:

```yaml
dependencies:
  # renovate: datasource=conda depName=main/pydantic
  - pydantic ==2.8.2
```

not the requirements.txt format, e.g.:

```
# renovate: datasource=conda depName=main/pydantic
pydantic ==2.8.2
```

Xref https://github.com/anaconda/conda-anaconda-telemetry/pull/115