### PR TITLE
Fix `UnboundLocalError` for test server

### DIFF
--- a/tests/http_test_server.py
+++ b/tests/http_test_server.py
@@ -153,7 +153,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    metadata: MetadataType
+    metadata: MetadataType | None = None
 
     def serve_metadata() -> Iterator[MetadataType]:
         nonlocal metadata


### PR DESCRIPTION
When starting the test server without any arguments we got an `UnboundLocalError`:

<img width="892" alt="Screenshot 2025-05-28 at 18 24 20" src="https://github.com/user-attachments/assets/5b6b39ab-98d6-43dd-b1fa-07845ecedd66" />
