### PR TITLE
Improve multi-user install TOS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,19 @@ Use `conda tos accept` to accept Terms of Service for all channels that require 
 </details>
 
 <details>
+<summary><h3>If I have a multi-user install, can I accept Terms of Service for all users?</h3></summary>
+
+If you are setting up Anaconda Distribution or Miniconda on behalf of members of your company, you can globally accept the Terms of Service for all users on a system.
+
+```bash
+conda tos accept --system
+```
+
+If unrelated individual users are accessing Anaconda Distribution or Miniconda on the system, instead instruct users to accept the Terms of Service on an individual basis.
+
+</details>
+
+<details>
 <summary><h3>Is my personal information shared when I accept the ToS?</h3></summary>
 
 No, the plugin uses anonymous tokens rather than personal identifiers. Only the acceptance record with timestamp is stored locally and transmitted to the repository.


### PR DESCRIPTION
This PR comes from a conversation with @jezdez about changes made to the https://www.anaconda.com/docs/getting-started/advanced-install/multi-user page via https://anaconda.atlassian.net/browse/DOC-767. This page currently has the following advice about TOS acceptance for a full system:

```
If you are setting up Anaconda Distribution or Miniconda on behalf of members of your company, 
you can globally accept the Terms of Service for all users. If unrelated individual users are 
accessing Anaconda Distribution or Miniconda on the system, instead instruct users to accept 
the Terms of Service on an individual basis.
```

This decision was based on a conversation with legal here: https://anaconda.slack.com/archives/C02MP6VC3TK/p1779387412087239

I've added this info to the FAQ in this repo's readme to at least get the conversation started and make sure this is all okay with legal and from the plugin's perspective as well. Adding Cheng since he has a good relationship with legal as well.