### PR TITLE
Update test workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-14, macos-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13']
         conda-version: ['24.11', '25.1', '25.3', '25.5', '25.7', '25.9', '26.7']
         exclude:
@@ -70,11 +70,11 @@ jobs:
           - os: windows-latest
             python-version: '3.12'
           # macOS x86_64: only test lowest Python version
-          - os: macos-13
+          - os: macos-14
             python-version: '3.11'
-          - os: macos-13
+          - os: macos-14
             python-version: '3.12'
-          - os: macos-13
+          - os: macos-14
             python-version: '3.13'
           # macOS arm64: only test highest Python version
           - os: macos-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-14, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13']
         conda-version: ['24.11', '25.1', '25.3', '25.5', '25.7', '25.9', '26.7']
         exclude:
@@ -69,13 +69,6 @@ jobs:
             python-version: '3.11'
           - os: windows-latest
             python-version: '3.12'
-          # macOS x86_64: only test lowest Python version
-          - os: macos-14
-            python-version: '3.11'
-          - os: macos-14
-            python-version: '3.12'
-          - os: macos-14
-            python-version: '3.13'
           # macOS arm64: only test highest Python version
           - os: macos-latest
             python-version: '3.10'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13']
-        conda-version: ['24.11', '25.1', '25.3', '25.5', '25.7', '25.9', '26.7']
+        conda-version: ['24.11', '25.1', '25.3', '25.5', '25.7', '25.9']
         exclude:
           # Windows: only test lowest and highest Python versions
           - os: windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,32 +61,22 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        conda-version: ['24.11', '25.1', '25.3', '25.5', '25.7', '25.9']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+        conda-version: ['24.11', '25.1', '25.3', '25.5', '25.7', '25.9', '26.7']
         exclude:
           # Windows: only test lowest and highest Python versions
-          - os: windows-latest
-            python-version: '3.10'
           - os: windows-latest
             python-version: '3.11'
           - os: windows-latest
             python-version: '3.12'
           # macOS x86_64: only test lowest Python version
           - os: macos-13
-            python-version: '3.10'
-          - os: macos-13
             python-version: '3.11'
           - os: macos-13
             python-version: '3.12'
           - os: macos-13
             python-version: '3.13'
-          # macOS x86_64: no conda 25.9 for Python 3.9
-          - os: macos-13
-            python-version: '3.9'
-            conda-version: '25.9'
           # macOS arm64: only test highest Python version
-          - os: macos-latest
-            python-version: '3.9'
           - os: macos-latest
             python-version: '3.10'
           - os: macos-latest

--- a/conda_anaconda_tos/console/render.py
+++ b/conda_anaconda_tos/console/render.py
@@ -35,8 +35,8 @@ from .prompt import FuzzyPrompt
 
 if TYPE_CHECKING:
     import os
-    from collections.abc import Iterable
-    from typing import Any, Callable, Final
+    from collections.abc import Callable, Iterable
+    from typing import Any, Final
 
     from conda.models.channel import Channel
 
@@ -476,7 +476,7 @@ def render_info(
         table.add_column("Key")
         table.add_column("Value")
         for key, value in data.items():
-            if isinstance(value, (tuple, list)):
+            if isinstance(value, tuple | list):
                 value = "\n".join(map(str, value))
             else:
                 value = str(value)

--- a/conda_anaconda_tos/local.py
+++ b/conda_anaconda_tos/local.py
@@ -33,7 +33,7 @@ def write_metadata(
     channel = Channel(channel)
     if not channel.base_url:
         raise ValueError("`channel` must have a base URL.")
-    if not isinstance(metadata, (LocalToSMetadata, RemoteToSMetadata)):
+    if not isinstance(metadata, LocalToSMetadata | RemoteToSMetadata):
         raise TypeError("`metadata` must be a LocalToSMetadata or RemoteToSMetadata.")
 
     # create/update ToSMetadata object

--- a/conda_anaconda_tos/plugin.py
+++ b/conda_anaconda_tos/plugin.py
@@ -40,8 +40,7 @@ from .remote import ENDPOINT
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
-    from collections.abc import Iterator
-    from typing import Callable
+    from collections.abc import Callable, Iterator
 
 
 #: Default metadata storage location.

--- a/conda_anaconda_tos/remote.py
+++ b/conda_anaconda_tos/remote.py
@@ -80,7 +80,7 @@ def get_cached_endpoint(
 
     # argument validation/coercion
     path = get_cache_path(channel)
-    if not isinstance(cache_timeout, (int, float)):
+    if not isinstance(cache_timeout, int | float):
         raise TypeError("`cache_timeout` must be an integer, float, or falsy.")
 
     # get mtime of cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -26,7 +25,7 @@ description = "Conda subcommand to view, accept, and interact with a channel's T
 dynamic = ["version"]
 license = {file = "LICENSE"}
 name = "conda-anaconda-tos"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 [project.entry-points.conda]
 conda-anaconda-tos = "conda_anaconda_tos.plugin"
@@ -87,7 +86,7 @@ markers = [
 testpaths = ["tests"]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.lint]
 extend-per-file-ignores = {"tests/*" = ["D", "S101"]}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,12 +18,12 @@ requirements:
   build:
     - git  # for source/git_url above
   host:
-    - python >=3.9
+    - python >=3.10
     - pip
     - hatchling >=1.12.2
     - hatch-vcs >=0.2.0
   run:
-    - python >=3.9
+    - python >=3.10
     - conda >=24.11
     - rich
     - pydantic

--- a/tests/http_test_server.py
+++ b/tests/http_test_server.py
@@ -45,7 +45,7 @@ def run_test_server(
 
     # convert single metadata to an infinite iterator
     metadatas: Iterator[MetadataType]
-    if isinstance(metadata, (RemoteToSMetadata, str)) or metadata is None:
+    if isinstance(metadata, RemoteToSMetadata | str) or metadata is None:
         metadatas = repeat(metadata)
     else:
         metadatas = metadata
@@ -98,7 +98,7 @@ class MutableToSMetadata(RemoteToSMetadata):
 
     def __eq__(self: Self, other: object) -> bool:
         return (
-            isinstance(other, (MutableToSMetadata, RemoteToSMetadata))
+            isinstance(other, MutableToSMetadata | RemoteToSMetadata)
             and self.model_dump() == other.model_dump()
         )
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 conda >=24.11
 # renovate: datasource=conda depName=main/pydantic
 pydantic ==2.11.7
-python >=3.9
+python >=3.10
 # renovate: datasource=conda depName=main/rich
 rich ==13.9.4


### PR DESCRIPTION
## Summary
Split from #295 

While working on #295, CI failures appeared because the test matrix still used retired runners (notably macos-13). This PR updates `.github/workflows/tests.yml` so the workflow runs on current GitHub-hosted images and drops an unsupported Python version (3.9).
## Changes
- Drop macos-13 (retired Intel x86_64 image; jobs were stuck waiting for runners)
- Drop Python 3.9 from the matrix (floor is now 3.10)